### PR TITLE
Proposta de abertura de Meetup em Lisboa - Portugal

### DIFF
--- a/meetups.md
+++ b/meetups.md
@@ -6,8 +6,9 @@ Se você deseja iniciar um Meetup, leia a nossa [documentação](README.md#como-
 
 ## Meetups
 
-| cidade | estado | link para o meetup.com | responsável | coordenação |
-|---|---|---|---|---|
-| São Paulo | SP  | https://www.meetup.com/pt-BR/Training-Center-SP/  | [Luiz Felipe Limeira](https://twitter.com/lflimeira02 ) | [Fernanda Bernardo](https://twitter.com/Feh_Bernardo), [William Oliveira](https://twitter.com/w_oliveiras), [Lucas Santos](https://twitter.com/_StaticVoid) |
-| Porto Alegre | RS | https://www.meetup.com/pt-BR/Training-Center-RS/ | [Felipe Andrade](https://twitter.com/felipeSGAndrade) | [Aline Bastos](https://twitter.com/AlineBastos), [Adeonir Kohl](https://twitter.com/adeonir) |
-| Curitiba | PR | https://www.meetup.com/pt-BR/Training-Center-CWB/ | [Marcela Bomfim](https://twitter.com/cecelabomfim) | [Mariana Brito](https://twitter.com/briitomari) |
+| cidade | estado | país | link para o meetup.com | responsável | coordenação |
+|---|---|---|---|---|---|
+| São Paulo | SP  | BR | https://www.meetup.com/pt-BR/Training-Center-SP/  | [Luiz Felipe Limeira](https://twitter.com/lflimeira02 ) | [Fernanda Bernardo](https://twitter.com/Feh_Bernardo), [William Oliveira](https://twitter.com/w_oliveiras), [Lucas Santos](https://twitter.com/_StaticVoid) |
+| Porto Alegre | RS | BR | https://www.meetup.com/pt-BR/Training-Center-RS/ | [Felipe Andrade](https://twitter.com/felipeSGAndrade) | [Aline Bastos](https://twitter.com/AlineBastos), [Adeonir Kohl](https://twitter.com/adeonir) |
+| Curitiba | PR | BR | https://www.meetup.com/pt-BR/Training-Center-CWB/ | [Marcela Bomfim](https://twitter.com/cecelabomfim) | [Mariana Brito](https://twitter.com/briitomari) |
+| Lisboa | LX | PT | https://www.meetup.com/pt-BR/Training-Center-LX/ | [Wendell Adriel](https://wendelladriel.com) | [Caio Alcântara](https://github.com/clucasalcantara), [Mate Paiva](http://matepaiva.github.io/)


### PR DESCRIPTION
Desejo iniciar um Meetup em Lisboa para tentar disseminar o projeto Training Center para fora do país e tentar fazer com que a cultura de partilha de conhecimento se espalhe.

Com o Meetup iremos fortalecer a comunidade local, ajudar mais pessoas e aumentar o networking.

**Eu concordo com o código de conduta.**